### PR TITLE
workaround for concurrent download issue.

### DIFF
--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/tools/IOUtils.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/tools/IOUtils.java
@@ -410,7 +410,7 @@ public class IOUtils {
             //noinspection ResultOfMethodCallIgnored
             targetFolder.delete();
         }
-        return targetFolder.mkdirs();
+        return targetFolder.mkdirs() || targetFolder.isDirectory();
     }
 
     /**


### PR DESCRIPTION
Description:
When download multi files into the same dir, will cause SDcard I/O issue sometimes.
File.mkdirs() returns false if the directory already existed. If you want to know whether the directory exists on return, either use (f.mkdirs() || f.isDirectory()) or simply ignore the return value from this method.

Resolution:
use (File.mkdirs() || File.isDirectory()) instead.